### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -23,6 +23,8 @@ env:
   
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest    
     steps:
     - uses: actions/checkout@v4.1.4


### PR DESCRIPTION
Potential fix for [https://github.com/FSchiltz/Helse/security/code-scanning/8](https://github.com/FSchiltz/Helse/security/code-scanning/8)

To fix this problem, the workflow should specify a `permissions` block that explicitly limits the permissions of the `GITHUB_TOKEN`. This block can be set at the root (applies to all jobs by default) or per job (overrides root defaults for that job). The secure approach is to set the root-level permission to `contents: read` (the minimum for typical build tasks), and *if* a job needs higher permissions (like uploading to a release), elevate only for that job, e.g., `contents: write`. For this workflow:

- **Edit**: Insert at the workflow root (after `name:` and before `on:`), or just after `on:`.
- **Set**: `permissions: contents: read` (default).
- **If any job needs elevated permissions** (e.g., the step that runs `gh release upload`), set `permissions: contents: write` for that specific job. However, since only a step in the `build` job does the upload, grant `contents: write` to the whole `build` job.
- **Implementation**: 
  - Add to line 25 (under `build:`): `permissions: contents: write`
  - Or, if you want to restrict only the release upload step, you would need to split that step into a separate job, but as shown, it's in the single `build` job—thus, set job-level permission.

No additional methods, imports, or external definitions are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
